### PR TITLE
Fix button width in 4-Accordion

### DIFF
--- a/4-accordion/final/src/index.css
+++ b/4-accordion/final/src/index.css
@@ -209,4 +209,5 @@ main {
   cursor: pointer;
   margin-left: 1rem;
   align-self: center;
+  min-width: 2rem;
 }


### PR DESCRIPTION
In the Accordion project, the buttons become squished when the header text wraps in small screen sizes (less than 700px). The text header in the question component takes up as much space as possible in the flexbox, which causes the button to have a smaller width when the text wraps. By adding a `min-width: 2rem` rule to the btn class, the button will always have the required width.

<img width="421" alt="Screen Shot 2020-12-21 at 4 09 24 PM" src="https://user-images.githubusercontent.com/4750816/102824463-de6b3000-43aa-11eb-975a-9b79ceb23ed9.png">


Small nitpick, great course! 🙂

