### PR TITLE
fix: link text random to home

### DIFF
--- a/11-navbar/setup/src/data.js
+++ b/11-navbar/setup/src/data.js
@@ -4,7 +4,7 @@ export const links = [
   {
     id: 1,
     url: '/',
-    text: 'random',
+    text: 'home',
   },
   {
     id: 2,


### PR DESCRIPTION
Fixed link text from `random` to `home` in the `data.js` file - https://github.com/john-smilga/react-projects/blob/master/11-navbar/setup/src/data.js. 
## Before
![image](https://user-images.githubusercontent.com/69510006/226393186-178dd68f-1def-4e77-bd92-20ba2e40cb93.png)

## After
![image](https://user-images.githubusercontent.com/69510006/226394313-be45f8c7-c35d-4e14-a244-a93094e52a8b.png)

