### PR TITLE
remove color state string

### DIFF
--- a/09-color-generator/final/src/App.js
+++ b/09-color-generator/final/src/App.js
@@ -4,7 +4,7 @@ import SingleColor from './SingleColor'
 import Values from 'values.js'
 
 function App() {
-  const [color, setColor] = useState('')
+  const [color, setColor] = useState()
   const [error, setError] = useState(false)
   const [list, setList] = useState(new Values('#f15025').all(10))
 


### PR DESCRIPTION
Remove color string then no need to face  **Unable to parse color from string** error 
Also you use input default value which means (placeholder values) also show  result it if remove string

Placeholder Values 
![image](https://github.com/john-smilga/react-projects/assets/91749601/99f4f6d7-2d8b-4aaa-9f34-0049aa7bc3ff)

Result (which means no error )
![image](https://github.com/john-smilga/react-projects/assets/91749601/9a547f2e-1937-41b3-9ab9-251366c8764d)

 